### PR TITLE
Roleplaying features: User titles

### DIFF
--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 dotenv = "0.14"
 env_logger = "0.6"
+heck = "0.3"
 log = "0.4"
 rand = "0.7"
 reqwest = "0.9"

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 [dependencies]
 dotenv = "0.14"
 env_logger = "0.6"
-heck = "0.3"
 log = "0.4"
 rand = "0.7"
 reqwest = "0.9"

--- a/app/src/commands/mod.rs
+++ b/app/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod general;
 pub mod cat;
 pub mod roll;
+pub mod user;

--- a/app/src/commands/user/mod.rs
+++ b/app/src/commands/user/mod.rs
@@ -1,0 +1,191 @@
+use crate::database;
+use serenity::{
+    prelude::*,
+    model::prelude::*,
+    framework::standard::{
+        CommandError,
+        CommandResult,
+        macros::command,
+    },
+    utils::MessageBuilder,
+};
+
+const MAX_TITLE_LENGTH: usize = 128;
+
+#[command]
+#[description = "Gets, sets or clears your title."]
+#[usage = "`!title`, `!title set ...` or `!title clear`."]
+fn title(ctx: &mut Context, msg: &Message) -> CommandResult {
+    debug!("title command handler called");
+
+    let args: Vec<&str> = msg.content.split(' ').collect();
+
+    match args.get(1) {
+        None => handle_get_title(ctx, msg),
+        Some(&"set") => {
+            match args.get(2..args.len()) {
+                None => {
+                    let response = MessageBuilder::new()
+                        .push_bold_safe(&msg.author)
+                        .push(", Usage: `!title set The Fabulous`")
+                        .build();
+
+                    if let Err(why) = msg.channel_id.say(&ctx.http, &response) {
+                        error!("Error sending message: {:?}", why);
+                    }
+
+                    // This is a usage error, not a bot failure
+                    Ok(())
+                },
+                Some(title_args) => {
+                    let new_title = title_args.join(" ");
+                    handle_set_title(ctx, msg, Some(new_title))
+                },
+            }
+        },
+        Some(&"clear") => handle_set_title(ctx, msg, None),
+        Some(_) => {
+            // Unrecognised argument
+            let response = MessageBuilder::new()
+                .push_bold_safe(&msg.author)
+                .push(", unrecognised !title subcommand. ")
+                .push("use `!title`, `!title set ...` or `!title clear`.")
+                .build();
+
+            if let Err(why) = msg.channel_id.say(&ctx.http, &response) {
+                error!("Error sending message: {:?}", why);
+            }
+            // User error
+            return Ok(())
+        }
+    }
+}
+
+fn handle_get_title(
+    ctx: &mut Context,
+    msg: &Message,
+) -> CommandResult
+{
+    // User ID of the user executing the command
+    let user_id = msg.author.id;
+
+    debug!("User DB data retrieval...");
+    let database = database::Handle::new();
+    let user: database::User = match database.user(user_id.0)
+    {
+        Err(_) => {
+            let reason = String::from("Could not retrieve user data from database");
+            error!("{}", reason);
+            return Err(CommandError(reason))
+        },
+        Ok(data) => data,
+    };
+
+    let response = match user.title {
+        None => MessageBuilder::new()
+            .push_bold_safe(&msg.author)
+            .push(", you don't have a title! Use `!title set ...` to set one.")
+            .build(),
+        Some(title) => MessageBuilder::new()
+            .push_bold_safe(&msg.author)
+            .push(", your title is ")
+            .push_bold(title)
+            .push(".")
+            .build(),
+    };
+
+    if let Err(why) = msg.channel_id.say(&ctx.http, &response) {
+        error!("Error sending message: {:?}", why);
+    }
+
+    Ok(())
+}
+
+fn handle_set_title(
+    ctx: &mut Context,
+    msg: &Message,
+    title: Option<String>
+) -> CommandResult
+{
+    // Nothing to validate if title is None
+    let title: Option<String> = match title {
+        None => None,
+        Some(title) => {
+            debug!("Formatting title {:?}...", title);
+            let title = String::from(title.trim_matches(' '));
+            if title.is_empty() {
+                // Empty, or had emojis or other characters removed by to_snake_case
+                let response = MessageBuilder::new()
+                    .push_bold_safe(&msg.author)
+                    .push(", sorry, that didn't work. Try a different title!")
+                    .build();
+                if let Err(why) = msg.channel_id.say(&ctx.http, &response) {
+                    error!("Error sending message: {:?}", why);
+                }
+                // User error
+                return Ok(())
+            }
+            if title.len() > MAX_TITLE_LENGTH {
+                // Title is too long
+                let response = MessageBuilder::new()
+                    .push_bold_safe(&msg.author)
+                    .push(", please choose a shorter title!")
+                    .build();
+                if let Err(why) = msg.channel_id.say(&ctx.http, &response) {
+                    error!("Error sending message: {:?}", why);
+                }
+                // User error
+                return Ok(())
+            }
+            debug!("Resulting title: {:?}", title);
+            Some(title)
+        }
+    };
+
+    // User ID of the user executing the command
+    let user_id = msg.author.id;
+
+    debug!("User DB data retrieval...");
+    let database = database::Handle::new();
+    let mut user: database::User = match database.user(user_id.0)
+    {
+        Err(_) => {
+            let reason = String::from("Could not retrieve user data from database");
+            error!("{}", reason);
+            return Err(CommandError(reason))
+        },
+        Ok(data) => data,
+    };
+
+    user.title = title.clone();
+
+    debug!("Updating user DB entry...");
+    if let Err(_) = database.user_update(
+        user_id.0,
+        &user
+    ) {
+        let reason = String::from("Could update user data in database");
+        error!("{}", reason);
+        return Err(CommandError(reason))
+    }
+    debug!("Updated user title in database to '{:?}'", user.title);
+
+    let response = match title {
+        Some(title) => MessageBuilder::new()
+            .push_bold_safe(&msg.author)
+            .push(", set your title to ")
+            .push_bold(title)
+            .push("!")
+            .build(),
+        None => MessageBuilder::new()
+            .push_bold_safe(&msg.author)
+            .push(", cleared your title!")
+            .build(),
+    };
+
+    if let Err(why) = msg.channel_id.say(&ctx.http, &response) {
+        error!("Error sending message: {:?}", why);
+    }
+
+    Ok(())
+}

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,5 +1,5 @@
 #[macro_use] extern crate log;
-//
+
 mod commands;
 mod database;
 mod stream_notify;
@@ -7,7 +7,8 @@ mod stream_notify;
 use commands::{
     general::*,
     cat::cat::*,
-    roll::*
+    roll::*,
+    user::*,
 };
 use dotenv;
 use serenity::{
@@ -64,10 +65,16 @@ group!({
     ],
 });
 
-group!({ 
+group!({
     name: "cat",
     options: {},
     commands: [cat],
+});
+
+group!({
+    name: "user",
+    options: {},
+    commands: [title],
 });
 
 #[help]
@@ -156,6 +163,7 @@ fn main() {
         .help(&MY_HELP)
         .group(&GENERAL_GROUP)
         .group(&CAT_GROUP)
+        .group(&USER_GROUP)
     );
 
     if let Err(why) = client.start() {

--- a/mount/sql/002_user_roleplay_title.sql
+++ b/mount/sql/002_user_roleplay_title.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE Users ADD COLUMN Title TEXT;
+
+PRAGMA user_version=2;
+
+COMMIT;


### PR DESCRIPTION
- Usability improvement to DB getter funcs user(), guild() and member(): where no entry exists in the DB, return a default User, Guild or Member struct instance
- Alter DB Users table to include Title column (text for storing a user's title)
- Add !title command to allow users to get, set and clear their title (which also supports emojis)
- During stream shoutouts, user titles will be prefixed onto the user display name